### PR TITLE
Fix Edge reader loading error

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1133,6 +1133,10 @@ Helpers.polyfillCaretRangeFromPoint = function(document) {
 };
 
 Helpers.detectScrollOffsetTechniqueSupport = function(document) {
+    if(Helpers.scrollOffsetTechniqueSupport){
+        return Helpers.scrollOffsetTechniqueSupport;
+    }
+
     var iframe = document.createElement('iframe');
     document.documentElement.appendChild(iframe);
     var iframeDoc = iframe.contentDocument;
@@ -1160,9 +1164,9 @@ Helpers.detectScrollOffsetTechniqueSupport = function(document) {
         "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.");
     var scrollingEl = iframeDoc.scrollingElement || iframeDoc.body;
     scrollingEl.scrollLeft = 50;
-    var test = scrollingEl.scrollLeft === 50;
+    Helpers.scrollOffsetTechniqueSupport = scrollingEl.scrollLeft === 50;
     $(iframe).remove();
-    return test;
+    return Helpers.scrollOffsetTechniqueSupport;
 };
 
 Helpers.createStyleSheet = function(document, id) {

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -75,7 +75,6 @@ var ReflowableView = function(options, reader) {
 
     var _isScrollingInternal = false;
     var _supportsScrollOffsets = true;
-    var _skipNextResizeCallback = false;
 
 
     var _currentOpacity = -1;
@@ -706,16 +705,6 @@ var ReflowableView = function(options, reader) {
 
 
     function updatePagination(initiator) {
-        var epubContentDocument = _$iframe[0].contentDocument;
-
-        if (initiator !== Helpers.removeStyleSheet && _supportsScrollOffsets) {
-            Helpers.removeStyleSheet(epubContentDocument, 'scrolloffsets');
-            _.defer(function () {
-                updatePagination(Helpers.removeStyleSheet);
-            });
-            return;
-        }
-
         // At 100% font-size = 16px (on HTML, not body or descendant markup!)
         var MAXW = _paginationInfo.columnMaxWidth;
         var MINW = _paginationInfo.columnMinWidth;
@@ -928,17 +917,6 @@ var ReflowableView = function(options, reader) {
 
         }
 
-      if (_supportsScrollOffsets) {
-        if (_supportsScrollOffsets && _paginationInfo.columnCount % 2) {
-          _.defer(function () {
-            console.debug("... odd columns (setting skip flag)");
-            var sheet = Helpers.createStyleSheet(epubContentDocument, 'scrolloffsets');
-            sheet.insertRule('body::after{content:\' \';display:block;width:100%;height:100vh;visibility:hidden;}', 0);
-            _skipNextResizeCallback = true;
-          });
-        }
-      }
-
         updateDocumentSize();
 
         if (_expandDocumentFullWidth) {
@@ -966,7 +944,7 @@ var ReflowableView = function(options, reader) {
 
             console.debug("ReflowableView content resized ...", _lastDocumentSize.width, _lastDocumentSize.height, _currentSpineItem.idref);
 
-            if (documentSizeChanged && !_skipNextResizeCallback) {
+            if (documentSizeChanged) {
                 console.debug("... updating pagination.");
 
                 updatePagination(ResizeSensor);


### PR DESCRIPTION
Refer to issue AXNG-44.

Memoizes call to Helpers.detectScrollOffsetTechniqueSupport so that it doesn't try to access iframes after loading when it doesn't have permission.

Removes unnecessary call to Helpers.removeStyleSheet and related code(same reason as above).