### PR TITLE
Fix theme selection issue

### DIFF
--- a/js/models/style.js
+++ b/js/models/style.js
@@ -22,6 +22,8 @@
 //  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import _ from 'underscore';
+
 /**
  * @class Models.Style
  * @constructor
@@ -46,7 +48,8 @@ var Style = function(selector, declarations) {
      * @type 
      */
 
-    this.declarations = declarations;
+    //ensure original object is not overwritten
+    this.declarations = _.extend({}, declarations);
 
     /**
      * Set the declarations array


### PR DESCRIPTION
See AX-493 for ticket.

First background color selected works but only once. Changing it to something else and back will not work. This fixes that issue by using a new object to store the declaration information instead of using the first declaration object passed in.